### PR TITLE
Add built-in (inertial) manipulation via dep. properties

### DIFF
--- a/src/SampleApp/BooleanToScrollBarVisibility.cs
+++ b/src/SampleApp/BooleanToScrollBarVisibility.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Controls;
+using System.Windows.Data;
+
+namespace SampleApp
+{
+    public class BooleanToScrollBarVisibilityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType,
+            object parameter, CultureInfo culture)
+        {
+            var enabled = bool.Parse(value.ToString());
+            return enabled ? ScrollBarVisibility.Visible : ScrollBarVisibility.Disabled;
+        }
+
+        public object ConvertBack(object value, Type targetType,
+            object parameter, CultureInfo culture)
+        {
+            var visibility = (ScrollBarVisibility) value;
+            return visibility == ScrollBarVisibility.Visible;
+        }
+    }
+}

--- a/src/SampleApp/HalfLengthConverter.cs
+++ b/src/SampleApp/HalfLengthConverter.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace SampleApp
+{
+    public class HalfLengthConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType,
+            object parameter, CultureInfo culture)
+        {
+            return (double) value/2.0d;
+        }
+
+        public object ConvertBack(object value, Type targetType,
+            object parameter, CultureInfo culture)
+        {
+            return null;
+        }
+    }
+}

--- a/src/SampleApp/IncreaseLengthByIntConverter.cs
+++ b/src/SampleApp/IncreaseLengthByIntConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace SampleApp
+{
+    public class IncreaseLengthByIntConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType,
+            object parameter, CultureInfo culture)
+        {
+            int increaseBy;
+            int.TryParse(parameter.ToString(), out increaseBy);
+            return (double) value + increaseBy;
+        }
+
+        public object ConvertBack(object value, Type targetType,
+            object parameter, CultureInfo culture)
+        {
+            return null;
+        }
+    }
+}

--- a/src/SampleApp/MainWindow.xaml
+++ b/src/SampleApp/MainWindow.xaml
@@ -4,49 +4,101 @@
         xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
         Title="MainWindow" Height="350" Width="525"
         xmlns:recognizer="clr-namespace:Org.Interactivity.Recognizer;assembly=Org.Interactivity.Recognizer"
-        xmlns:ei="http://schemas.microsoft.com/expression/2010/interactions" WindowState="Maximized">
+        xmlns:ei="http://schemas.microsoft.com/expression/2010/interactions"
+        xmlns:sampleApp="clr-namespace:SampleApp"
+        WindowState="Maximized"
+        UseLayoutRounding="True">
+    <Window.Resources>
+        <sampleApp:BooleanToScrollBarVisibilityConverter x:Key="BooleanToScrollBarVisibilityConverter"/>
+        <sampleApp:HalfLengthConverter x:Key="HalfLengthConverter"/>
+        <sampleApp:IncreaseLengthByIntConverter x:Key="IncreaseLengthByIntConverter"/>
+    </Window.Resources>
     <Grid>
-        <Rectangle Stroke="#939393" Margin="5" StrokeThickness="2" StrokeDashArray="4 2" SnapsToDevicePixels="True"/>
-        <Grid x:Name="TouchArea" Margin="10" Background="Gray">
-            <i:Interaction.Triggers>
-                <recognizer:GestureRecognizer TriggerOnGesture="SwipeDown">
-                    <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="#000080" />
-                    <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Down with a single touch" />
-                </recognizer:GestureRecognizer>
-                <recognizer:GestureRecognizer TriggerOnGesture="SwipeDown" GestureModifier="TwoFingers">
-                    <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="#19198c" />
-                    <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Down with two touches" />
-                </recognizer:GestureRecognizer>
-                <recognizer:GestureRecognizer TriggerOnGesture="SwipeDown" GestureModifier="ThreeFingers">
-                    <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="#323299" />
-                    <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Down with three touches" />
-                </recognizer:GestureRecognizer>
-                <recognizer:GestureRecognizer TriggerOnGesture="SwipeDown" GestureModifier="FourFingers">
-                    <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="#4c4ca6" />
-                    <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Down with four touches" />
-                </recognizer:GestureRecognizer>
-                <recognizer:GestureRecognizer TriggerOnGesture="SwipeDown" GestureModifier="FiveFingers">
-                    <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="#6666b2" />
-                    <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Down with five touches" />
-                </recognizer:GestureRecognizer>
-                <recognizer:GestureRecognizer TriggerOnGesture="SwipeUp" GestureModifier="Any">
-                    <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="LightBlue" />
-                    <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Up" />
-                </recognizer:GestureRecognizer>
-                <recognizer:GestureRecognizer TriggerOnGesture="SwipeRight">
-                    <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="LightGreen" />
-                    <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Right" />
-                </recognizer:GestureRecognizer>
-                <recognizer:GestureRecognizer TriggerOnGesture="SwipeLeft">
-                    <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="DarkGreen" />
-                    <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Left" />
-                </recognizer:GestureRecognizer>
-                <recognizer:GestureRecognizer TriggerOnGesture="Tap">
-                    <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="LightPink" />
-                    <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was a Tap" />
-                </recognizer:GestureRecognizer>
-            </i:Interaction.Triggers>
-            <TextBlock x:Name="GestureRecognizedAs" VerticalAlignment="Top" HorizontalAlignment="Center" />
-        </Grid>
+        <TabControl>
+            <TabItem Header="Gestures">
+                <Grid>
+                    <Rectangle Stroke="#939393" Margin="5" StrokeThickness="2" StrokeDashArray="4 2" SnapsToDevicePixels="True">
+                        <i:Interaction.Triggers>
+                            <recognizer:GestureRecognizer TriggerOnGesture="All" AllowInertiaOnTranslate="True" TranslateWithManipulationEnabled="True"/>
+                        </i:Interaction.Triggers>
+                    </Rectangle>
+                    <Grid x:Name="TouchArea" Margin="10" Background="Gray">
+                        <i:Interaction.Triggers>
+                            <recognizer:GestureRecognizer TriggerOnGesture="SwipeDown">
+                                <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="#000080" />
+                                <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Down with a single touch" />
+                            </recognizer:GestureRecognizer>
+                            <recognizer:GestureRecognizer TriggerOnGesture="SwipeDown" GestureModifier="TwoFingers">
+                                <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="#19198c" />
+                                <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Down with two touches" />
+                            </recognizer:GestureRecognizer>
+                            <recognizer:GestureRecognizer TriggerOnGesture="SwipeDown" GestureModifier="ThreeFingers">
+                                <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="#323299" />
+                                <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Down with three touches" />
+                            </recognizer:GestureRecognizer>
+                            <recognizer:GestureRecognizer TriggerOnGesture="SwipeDown" GestureModifier="FourFingers">
+                                <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="#4c4ca6" />
+                                <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Down with four touches" />
+                            </recognizer:GestureRecognizer>
+                            <recognizer:GestureRecognizer TriggerOnGesture="SwipeDown" GestureModifier="FiveFingers">
+                                <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="#6666b2" />
+                                <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Down with five touches" />
+                            </recognizer:GestureRecognizer>
+                            <recognizer:GestureRecognizer TriggerOnGesture="SwipeUp" GestureModifier="Any">
+                                <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="LightBlue" />
+                                <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Up" />
+                            </recognizer:GestureRecognizer>
+                            <recognizer:GestureRecognizer TriggerOnGesture="SwipeRight">
+                                <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="LightGreen" />
+                                <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Right" />
+                            </recognizer:GestureRecognizer>
+                            <recognizer:GestureRecognizer TriggerOnGesture="SwipeLeft">
+                                <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="DarkGreen" />
+                                <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was Swipe Left" />
+                            </recognizer:GestureRecognizer>
+                            <recognizer:GestureRecognizer TriggerOnGesture="Tap">
+                                <ei:ChangePropertyAction TargetName="TouchArea" PropertyName="Background" Value="LightPink" />
+                                <ei:ChangePropertyAction TargetName="GestureRecognizedAs" PropertyName="Text" Value="Last gesture was a Tap" />
+                            </recognizer:GestureRecognizer>
+                        </i:Interaction.Triggers>
+                        <TextBlock x:Name="GestureRecognizedAs" VerticalAlignment="Top" HorizontalAlignment="Center" />
+                    </Grid>
+                </Grid>
+            </TabItem>
+            <TabItem Header="Manipulation">
+                <Grid x:Name="ScrollArea" Background="LightSteelBlue">
+                    <Rectangle Stroke="#939393" Margin="5" StrokeThickness="2" StrokeDashArray="4 2" SnapsToDevicePixels="True"/>
+                    <ScrollViewer HorizontalScrollBarVisibility="{Binding ElementName=HorizontalScrollEnabled, 
+                                                                          Path=IsChecked, 
+                                                                          Converter={StaticResource BooleanToScrollBarVisibilityConverter}, 
+                                                                          UpdateSourceTrigger=PropertyChanged}"
+                                  VerticalScrollBarVisibility="{Binding ElementName=VerticalScrollEnabled, 
+                                                                        Path=IsChecked, 
+                                                                        Converter={StaticResource BooleanToScrollBarVisibilityConverter}, 
+                                                                        UpdateSourceTrigger=PropertyChanged}">
+                        <i:Interaction.Triggers>
+                            <recognizer:GestureRecognizer TriggerOnGesture="All" AllowInertiaOnTranslate="True" TranslateWithManipulationEnabled="True"/>
+                        </i:Interaction.Triggers>
+                        <Canvas x:Name="EllipseHost" 
+                                Height="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Window}, Path=ActualHeight, Converter={StaticResource IncreaseLengthByIntConverter}, ConverterParameter=200}" 
+                                Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=Window}, Path=ActualWidth, Converter={StaticResource IncreaseLengthByIntConverter}, ConverterParameter=200}">
+                            <Ellipse Fill="White" 
+                                     Width="100"
+                                     Height="100"
+                                     Stroke="DimGray" 
+                                     StrokeThickness="1" 
+                                     StrokeDashArray="4 2" 
+                                     SnapsToDevicePixels="True"
+                                     Canvas.Left="{Binding ElementName=EllipseHost, Path=ActualWidth, Converter={StaticResource HalfLengthConverter}}"
+                                     Canvas.Top="{Binding ElementName=EllipseHost, Path=ActualHeight, Converter={StaticResource HalfLengthConverter}}"/>
+                        </Canvas>
+                    </ScrollViewer>
+                    <StackPanel HorizontalAlignment="Left" VerticalAlignment="Top" Margin="15 10">
+                        <CheckBox x:Name="HorizontalScrollEnabled" Content="Horizontal Scroll" Margin="5 4"/>
+                        <CheckBox x:Name="VerticalScrollEnabled" Content="Vertical Scroll" Margin="5 4"/>
+                    </StackPanel>
+                </Grid>
+            </TabItem>
+        </TabControl>
     </Grid>
 </Window>

--- a/src/SampleApp/SampleApp.csproj
+++ b/src/SampleApp/SampleApp.csproj
@@ -75,6 +75,9 @@
       <DependentUpon>App.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="BooleanToScrollBarVisibility.cs" />
+    <Compile Include="IncreaseLengthByIntConverter.cs" />
+    <Compile Include="HalfLengthConverter.cs" />
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>


### PR DESCRIPTION
Simple implementation that allows your "swipes" to translate, rotate, or zoom the attached `UIElement`. 

`ScrollViewer` supports translation of the `HorizontalOffset` and `VerticalOffset` properties. Arbitrary `UIElement`s support rotate, zoom, and translate with inertial movement (it will keep moving after you let off the screen).
